### PR TITLE
Remove use of OpenSSL(1) for generating a random key.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,6 @@ Requirements
 
 -  **xxd**, **base32**: to convert the hexadecimal secret to base32
 
--  **openssl** (optional, recommended): to create random secrets. If not
-   present, the script reads from ``/dev/urandom``.
-
 -  **qrencode** (optional, recommended): to create the qr code from the
    uri and display it on stdout.
 

--- a/gen-oath-safe
+++ b/gen-oath-safe
@@ -82,7 +82,6 @@ if [ -z "${QRTYPE}" ]; then
 fi
 
 # set commands
-_openssl="$(command -v openssl 2>/dev/null)"
 _qrencode="$(command -v qrencode 2>/dev/null)"
 _ykinfo="$(command -v ykinfo 2>/dev/null)"
 _ykp="$(command -v ykpersonalize 2>/dev/null)"
@@ -139,14 +138,8 @@ hexkey="$3"
 if [ -z "${hexkey}" ]; then
 	echo "INFO: No secret provided, generating random secret." >&2
 
-    # use openssl if existing, else use standard tools
-    if [ -x "${_openssl}" ]; then
-        hexkey="$($_openssl rand 1024)"
-    else
-        hexkey="$(head -c 1024 /dev/urandom | tr -d '\0')"
-    fi
-
     # create url-safe base32 with a length of 40 characters
+    hexkey="$(head -c 1024 /dev/urandom | tr -d '\0')"
     hexkey="$(printf '%s' "${hexkey}" | base32 | tr -dc '[:alpha:][digit]' | od -tx1 -An | tr -d '[:space:]' | head -c 40 | tr -d '\n')"
 fi
 

--- a/gen-oath-safe.1
+++ b/gen-oath-safe.1
@@ -29,7 +29,7 @@ The type of OTP token. Either \fBtotp\fR (time-based, default) or \fBhotp\fR (co
 .TP
 [\fISECRET\fR]
 The OTP secret as hex encoded string. If omitted, a secret of 40 characters 
-is randomly generated using either \fBopenssl\fR (if available) or \fB/dev/urandom\fR.
+is randomly generated using \fB/dev/urandom\fR.
 
 .SH BUGS
 .PP
@@ -50,7 +50,7 @@ by Thomas Zink. For complete list of contributors see
 
 .SH SEE ALSO
 .sp
-\fBoathtool\fP(1), \fBotptool\fP(1), \fBgenotpurl\fP(1), \fBqrencode\fP(1), \fBykinfo\fP(1), \fBopenssl\fP(1)
+\fBoathtool\fP(1), \fBotptool\fP(1), \fBgenotpurl\fP(1), \fBqrencode\fP(1), \fBykinfo\fP(1)
 .PP
 "HOTP: An HMAC-Based One-Time Password Algorithm" <http://www.ietf.org/rfc/rfc4226.txt>
 .PP


### PR DESCRIPTION
Follow the KISS principle: support for VMS and Cygwin (the only platforms which have bash and not working /dev/urandom) is not desired goal of this project.

Please, review and comment.